### PR TITLE
Add .props file to initialize all contract settings

### DIFF
--- a/nuget/CodeContracts.MSBuild/CodeContracts.MSBuild.nuspec
+++ b/nuget/CodeContracts.MSBuild/CodeContracts.MSBuild.nuspec
@@ -17,7 +17,7 @@
         <tags>CodeContracts Code Contracts MSBuild</tags>
     </metadata>
     <files>
-        <file src="build\CodeContracts.MSBuild.targets" target="build\CodeContracts.MSBuild.targets" />
+        <file src="build\CodeContracts.MSBuild.*" target="build\" />
         <file src="..\..\Contracts\**" target="Contracts" />
     </files>
 </package>

--- a/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
+++ b/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
@@ -1,0 +1,113 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--=====================================================================
+        CODE CONTRACT DEFAULTS.
+        All defaults are set as they were by the late Visual Studio extension,
+        except for enabling the static checker by default (otherwise the user
+        would not be adding the package in the first place).
+
+        Names in comments correspond to the the original property page.
+        ======================================================================-->
+
+    <!--=====================================================================
+        Runtime checking. If false, whole section is irrelevant.
+       ======================================================================-->
+    <CodeContractsEnableRuntimeChecking>False</CodeContractsEnableRuntimeChecking>
+
+    <!-- Assembly mode, 1 = standard, 2 = advanced.  -->
+    <CodeContractsAssemblyMode>1</CodeContractsAssemblyMode>
+
+    <!-- Level drop-down: Full, Pre and Post, Preconditions, ReleaseRequires, None -->
+    <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
+    <!-- [ ] Only public surface contracts -->
+    <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
+    <!-- [ ] Assert on contract failure -->
+    <CodeContractsRuntimeThrowOnFailure>False</CodeContractsRuntimeThrowOnFailure>
+    <!-- [ ] Call-site requires checking -->
+    <CodeContractsRuntimeCallSiteRequires>False</CodeContractsRuntimeCallSiteRequires>
+    <!-- [ ] Skip quantifiers -->
+    <CodeContractsRuntimeSkipQuantifiers>False</CodeContractsRuntimeSkipQuantifiers>
+
+    <!-- Customr rewriter methods / Assembly -->
+    <CodeContractsCustomRewriterAssembly />
+    <!-- Customr rewriter methods / Class -->
+    <CodeContractsCustomRewriterClass />
+
+    <!--=====================================================================
+        Static checking. If false, whole section is irrelevant.
+       ======================================================================-->
+    <CodeContractsRunCodeAnalysis>True</CodeContractsRunCodeAnalysis>
+
+    <!-- [X] Check non-null -->
+    <CodeContractsNonNullObligations>True</CodeContractsNonNullObligations>
+    <!-- [X] Check enum values -->
+    <CodeContractsEnumObligations>True</CodeContractsEnumObligations>
+    <!-- [X] Check redundant assume -->
+    <CodeContractsRedundantAssumptions>True</CodeContractsRedundantAssumptions>
+    <!-- [ ] Show entry assumptions -->
+    <CodeContractsSuggestAssumptions>False</CodeContractsSuggestAssumptions>
+    <!-- [ ] Suggest requires -->
+    <CodeContractsSuggestRequires>False</CodeContractsSuggestRequires>
+    <!-- [X] Suggest asserts to contracts -->
+    <CodeContractsAssertsToContractsCheckBox>True</CodeContractsAssertsToContractsCheckBox>
+    <!-- [X] Infer requires -->
+    <CodeContractsInferRequires>True</CodeContractsInferRequires>
+    <!-- [ ] Infer ensures -->
+    <CodeContractsInferEnsures>False</CodeContractsInferEnsures>
+    <!-- [X] Check arithmetic -->
+    <CodeContractsArithmeticObligations>True</CodeContractsArithmeticObligations>
+    <!-- [X] Check missing public requires -->
+    <CodeContractsMissingPublicRequiresAsWarnings>True</CodeContractsMissingPublicRequiresAsWarnings>
+    <!-- [X] Check redundant conditionals -->
+    <CodeContractsRedundantTests>True</CodeContractsRedundantTests>
+    <!-- [ ] Show external assumptions -->
+    <CodeContractsSuggestAssumptionsForCallees>False</CodeContractsSuggestAssumptionsForCallees>
+    <!-- [X] Suggest readonly fields -->
+    <CodeContractsSuggestReadonly>True</CodeContractsSuggestReadonly>
+    <!-- [X] Suggest necessary ensures -->
+    <CodeContractsNecessaryEnsures>True</CodeContractsNecessaryEnsures>
+    <!-- [ ] Infer invariants for readonly -->
+    <CodeContractsInferObjectInvariants>False</CodeContractsInferObjectInvariants>
+    <!-- [X] Infer ensures for autoproperties -->
+    <CodeContractsInferEnsuresAutoProperties>True</CodeContractsInferEnsuresAutoProperties>
+    <!-- [ ] Fail build on warnings -->
+    <CodeContractsFailBuildOnWarnings>False</CodeContractsFailBuildOnWarnings>
+    <!-- [X] Check array bounds -->
+    <CodeContractsBoundsObligations>True</CodeContractsBoundsObligations>
+    <!-- [ ] Check missing public ensures -->
+    <CodeContractsMissingPublicEnsuresAsWarnings>False</CodeContractsMissingPublicEnsuresAsWarnings>
+    <!-- [ ] Suggest object invariants -->
+    <CodeContractsSuggestObjectInvariants>False</CodeContractsSuggestObjectInvariants>
+
+    <!-- [X] Cache results -->
+    <CodeContractsCacheAnalysisResults>True</CodeContractsCacheAnalysisResults>
+    <!-- SQL Server -->
+    <CodeContractsSQLServerOption />
+    <!-- [ ] Skip the analysis if cannot connect to cache -->
+    <CodeContractsSkipAnalysisIfCannotConnectToCache>False</CodeContractsSkipAnalysisIfCannotConnectToCache>
+    <!-- Warning level slider, 0..3 -->
+    <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
+    <!-- [X] Be optimistic on external API -->
+    <CodeContractsBeingOptimisticOnExternal>True</CodeContractsBeingOptimisticOnExternal>
+    <!-- [ ] Baseline -->
+    <CodeContractsUseBaseLine>False</CodeContractsUseBaseLine>
+    <!-- Baseline file -->
+    <CodeContractsBaseLineFile />
+
+    <!-- Contract reference assembly -->
+    <CodeContractsReferenceAssembly>Build</CodeContractsReferenceAssembly>
+    <!-- [ ] Emit contracts into XML doc file -->
+    <CodeContractsEmitXMLDocs>False</CodeContractsEmitXMLDocs>
+
+    <!--=====================================================================
+        Advanced options.
+       ======================================================================-->
+
+    <!-- Extra contract library paths -->
+    <CodeContractsLibPaths />
+    <!-- Extra runtime checker options -->
+    <CodeContractsExtraRewriteOptions />
+    <!-- Extra static checker options -->
+    <CodeContractsExtraAnalysisOptions />
+  </PropertyGroup>
+</Project>

--- a/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
+++ b/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
@@ -12,102 +12,144 @@
     <!--=====================================================================
         Runtime checking. If false, whole section is irrelevant.
        ======================================================================-->
-    <CodeContractsEnableRuntimeChecking>False</CodeContractsEnableRuntimeChecking>
+    <CodeContractsEnableRuntimeChecking Condition="
+     '$(CodeContractsEnableRuntimeChecking)' == ''">False</CodeContractsEnableRuntimeChecking>
 
     <!-- Assembly mode, 1 = standard, 2 = advanced.  -->
-    <CodeContractsAssemblyMode>1</CodeContractsAssemblyMode>
+    <CodeContractsAssemblyMode Condition="
+     '$(CodeContractsAssemblyMode)' == ''">1</CodeContractsAssemblyMode>
 
     <!-- Level drop-down: Full, Pre and Post, Preconditions, ReleaseRequires, None -->
-    <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
+    <CodeContractsRuntimeCheckingLevel Condition="
+     '$(CodeContractsRuntimeCheckingLevel)' == ''">Full</CodeContractsRuntimeCheckingLevel>
     <!-- [ ] Only public surface contracts -->
-    <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
+    <CodeContractsRuntimeOnlyPublicSurface Condition="
+     '$(CodeContractsRuntimeOnlyPublicSurface)' == ''">False</CodeContractsRuntimeOnlyPublicSurface>
     <!-- [ ] Assert on contract failure -->
-    <CodeContractsRuntimeThrowOnFailure>False</CodeContractsRuntimeThrowOnFailure>
+    <CodeContractsRuntimeThrowOnFailure Condition="
+     '$(CodeContractsRuntimeThrowOnFailure)' == ''">False</CodeContractsRuntimeThrowOnFailure>
     <!-- [ ] Call-site requires checking -->
-    <CodeContractsRuntimeCallSiteRequires>False</CodeContractsRuntimeCallSiteRequires>
+    <CodeContractsRuntimeCallSiteRequires Condition="
+     '$(CodeContractsRuntimeCallSiteRequires)' == ''">False</CodeContractsRuntimeCallSiteRequires>
     <!-- [ ] Skip quantifiers -->
-    <CodeContractsRuntimeSkipQuantifiers>False</CodeContractsRuntimeSkipQuantifiers>
+    <CodeContractsRuntimeSkipQuantifiers Condition="
+     '$(CodeContractsRuntimeSkipQuantifiers)' == ''">False</CodeContractsRuntimeSkipQuantifiers>
 
-    <!-- Customr rewriter methods / Assembly -->
-    <CodeContractsCustomRewriterAssembly />
-    <!-- Customr rewriter methods / Class -->
-    <CodeContractsCustomRewriterClass />
+    <!-- Customer rewriter methods / Assembly -->
+    <CodeContractsCustomRewriterAssembly Condition="
+     '$(CodeContractsCustomRewriterAssembly)' == ''" />
+    <!-- Customer rewriter methods / Class -->
+    <CodeContractsCustomRewriterClass Condition="
+     '$(CodeContractsCustomRewriterClass)' == ''" />
 
     <!--=====================================================================
         Static checking. If false, whole section is irrelevant.
        ======================================================================-->
-    <CodeContractsRunCodeAnalysis>True</CodeContractsRunCodeAnalysis>
+    <CodeContractsRunCodeAnalysis Condition="
+     '$(CodeContractsRunCodeAnalysis)' == ''">True</CodeContractsRunCodeAnalysis>
 
     <!-- [X] Check non-null -->
-    <CodeContractsNonNullObligations>True</CodeContractsNonNullObligations>
+    <CodeContractsNonNullObligations Condition="
+     '$(CodeContractsNonNullObligations)' == ''">True</CodeContractsNonNullObligations>
     <!-- [X] Check enum values -->
-    <CodeContractsEnumObligations>True</CodeContractsEnumObligations>
+    <CodeContractsEnumObligations Condition="
+     '$(CodeContractsEnumObligations)' == ''">True</CodeContractsEnumObligations>
     <!-- [X] Check redundant assume -->
-    <CodeContractsRedundantAssumptions>True</CodeContractsRedundantAssumptions>
+    <CodeContractsRedundantAssumptions Condition="
+     '$(CodeContractsRedundantAssumptions)' == ''">True</CodeContractsRedundantAssumptions>
     <!-- [ ] Show entry assumptions -->
-    <CodeContractsSuggestAssumptions>False</CodeContractsSuggestAssumptions>
+    <CodeContractsSuggestAssumptions Condition="
+     '$(CodeContractsSuggestAssumptions)' == ''">False</CodeContractsSuggestAssumptions>
     <!-- [ ] Suggest requires -->
-    <CodeContractsSuggestRequires>False</CodeContractsSuggestRequires>
+    <CodeContractsSuggestRequires Condition="
+     '$(CodeContractsSuggestRequires)' == ''">False</CodeContractsSuggestRequires>
     <!-- [X] Suggest asserts to contracts -->
-    <CodeContractsAssertsToContractsCheckBox>True</CodeContractsAssertsToContractsCheckBox>
+    <CodeContractsAssertsToContractsCheckBox Condition="
+     '$(CodeContractsAssertsToContractsCheckBox)' == ''">True</CodeContractsAssertsToContractsCheckBox>
     <!-- [X] Infer requires -->
-    <CodeContractsInferRequires>True</CodeContractsInferRequires>
+    <CodeContractsInferRequires Condition="
+     '$(CodeContractsInferRequires)' == ''">True</CodeContractsInferRequires>
     <!-- [ ] Infer ensures -->
-    <CodeContractsInferEnsures>False</CodeContractsInferEnsures>
+    <CodeContractsInferEnsures Condition="
+     '$(CodeContractsInferEnsures)' == ''">False</CodeContractsInferEnsures>
     <!-- [X] Check arithmetic -->
-    <CodeContractsArithmeticObligations>True</CodeContractsArithmeticObligations>
+    <CodeContractsArithmeticObligations Condition="
+     '$(CodeContractsArithmeticObligations)' == ''">True</CodeContractsArithmeticObligations>
     <!-- [X] Check missing public requires -->
-    <CodeContractsMissingPublicRequiresAsWarnings>True</CodeContractsMissingPublicRequiresAsWarnings>
+    <CodeContractsMissingPublicRequiresAsWarnings Condition="
+     '$(CodeContractsMissingPublicRequiresAsWarnings)' == ''">True</CodeContractsMissingPublicRequiresAsWarnings>
     <!-- [X] Check redundant conditionals -->
-    <CodeContractsRedundantTests>True</CodeContractsRedundantTests>
+    <CodeContractsRedundantTests Condition="
+     '$(CodeContractsRedundantTests)' == ''">True</CodeContractsRedundantTests>
     <!-- [ ] Show external assumptions -->
-    <CodeContractsSuggestAssumptionsForCallees>False</CodeContractsSuggestAssumptionsForCallees>
+    <CodeContractsSuggestAssumptionsForCallees Condition="
+     '$(CodeContractsSuggestAssumptionsForCallees)' == ''">False</CodeContractsSuggestAssumptionsForCallees>
     <!-- [X] Suggest readonly fields -->
-    <CodeContractsSuggestReadonly>True</CodeContractsSuggestReadonly>
+    <CodeContractsSuggestReadonly Condition="
+     '$(CodeContractsSuggestReadonly)' == ''">True</CodeContractsSuggestReadonly>
     <!-- [X] Suggest necessary ensures -->
-    <CodeContractsNecessaryEnsures>True</CodeContractsNecessaryEnsures>
+    <CodeContractsNecessaryEnsures Condition="
+     '$(CodeContractsNecessaryEnsures)' == ''">True</CodeContractsNecessaryEnsures>
     <!-- [ ] Infer invariants for readonly -->
-    <CodeContractsInferObjectInvariants>False</CodeContractsInferObjectInvariants>
+    <CodeContractsInferObjectInvariants Condition="
+     '$(CodeContractsInferObjectInvariants)' == ''">False</CodeContractsInferObjectInvariants>
     <!-- [X] Infer ensures for autoproperties -->
-    <CodeContractsInferEnsuresAutoProperties>True</CodeContractsInferEnsuresAutoProperties>
+    <CodeContractsInferEnsuresAutoProperties Condition="
+     '$(CodeContractsInferEnsuresAutoProperties)' == ''">True</CodeContractsInferEnsuresAutoProperties>
     <!-- [ ] Fail build on warnings -->
-    <CodeContractsFailBuildOnWarnings>False</CodeContractsFailBuildOnWarnings>
+    <CodeContractsFailBuildOnWarnings Condition="
+     '$(CodeContractsFailBuildOnWarnings)' == ''">False</CodeContractsFailBuildOnWarnings>
     <!-- [X] Check array bounds -->
-    <CodeContractsBoundsObligations>True</CodeContractsBoundsObligations>
+    <CodeContractsBoundsObligations Condition="
+     '$(CodeContractsBoundsObligations)' == ''">True</CodeContractsBoundsObligations>
     <!-- [ ] Check missing public ensures -->
-    <CodeContractsMissingPublicEnsuresAsWarnings>False</CodeContractsMissingPublicEnsuresAsWarnings>
+    <CodeContractsMissingPublicEnsuresAsWarnings Condition="
+     '$(CodeContractsMissingPublicEnsuresAsWarnings)' == ''">False</CodeContractsMissingPublicEnsuresAsWarnings>
     <!-- [ ] Suggest object invariants -->
-    <CodeContractsSuggestObjectInvariants>False</CodeContractsSuggestObjectInvariants>
+    <CodeContractsSuggestObjectInvariants Condition="
+     '$(CodeContractsSuggestObjectInvariants)' == ''">False</CodeContractsSuggestObjectInvariants>
 
     <!-- [X] Cache results -->
-    <CodeContractsCacheAnalysisResults>True</CodeContractsCacheAnalysisResults>
+    <CodeContractsCacheAnalysisResults Condition="
+     '$(CodeContractsCacheAnalysisResults)' == ''">True</CodeContractsCacheAnalysisResults>
     <!-- SQL Server -->
-    <CodeContractsSQLServerOption />
+    <CodeContractsSQLServerOption Condition="
+     '$(CodeContractsSQLServerOption)' == ''" />
     <!-- [ ] Skip the analysis if cannot connect to cache -->
-    <CodeContractsSkipAnalysisIfCannotConnectToCache>False</CodeContractsSkipAnalysisIfCannotConnectToCache>
+    <CodeContractsSkipAnalysisIfCannotConnectToCache Condition="
+     '$(CodeContractsSkipAnalysisIfCannotConnectToCache)' == ''">False</CodeContractsSkipAnalysisIfCannotConnectToCache>
     <!-- Warning level slider, 0..3 -->
-    <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
+    <CodeContractsAnalysisWarningLevel Condition="
+     '$(CodeContractsAnalysisWarningLevel)' == ''">0</CodeContractsAnalysisWarningLevel>
     <!-- [X] Be optimistic on external API -->
-    <CodeContractsBeingOptimisticOnExternal>True</CodeContractsBeingOptimisticOnExternal>
+    <CodeContractsBeingOptimisticOnExternal Condition="
+     '$(CodeContractsBeingOptimisticOnExternal)' == ''">True</CodeContractsBeingOptimisticOnExternal>
     <!-- [ ] Baseline -->
-    <CodeContractsUseBaseLine>False</CodeContractsUseBaseLine>
+    <CodeContractsUseBaseLine Condition="
+     '$(CodeContractsUseBaseLine)' == ''">False</CodeContractsUseBaseLine>
     <!-- Baseline file -->
-    <CodeContractsBaseLineFile />
+    <CodeContractsBaseLineFile Condition="
+     '$()CodeContractsBaseLineFile' == ''" />
 
     <!-- Contract reference assembly -->
-    <CodeContractsReferenceAssembly>Build</CodeContractsReferenceAssembly>
+    <CodeContractsReferenceAssembly Condition="
+     '$(CodeContractsReferenceAssembly)' == ''">Build</CodeContractsReferenceAssembly>
     <!-- [ ] Emit contracts into XML doc file -->
-    <CodeContractsEmitXMLDocs>False</CodeContractsEmitXMLDocs>
+    <CodeContractsEmitXMLDocs Condition="
+     '$(CodeContractsEmitXMLDocs)' == ''">False</CodeContractsEmitXMLDocs>
 
     <!--=====================================================================
         Advanced options.
        ======================================================================-->
 
     <!-- Extra contract library paths -->
-    <CodeContractsLibPaths />
+    <CodeContractsLibPaths Condition="
+     '$(CodeContractsLibPaths)' == ''" />
     <!-- Extra runtime checker options -->
-    <CodeContractsExtraRewriteOptions />
+    <CodeContractsExtraRewriteOptions Condition="
+     '$(CodeContractsExtraRewriteOptions)' == ''" />
     <!-- Extra static checker options -->
-    <CodeContractsExtraAnalysisOptions />
+    <CodeContractsExtraAnalysisOptions Condition="
+     '$(CodeContractsExtraAnalysisOptions)' == ''" />
   </PropertyGroup>
 </Project>

--- a/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
+++ b/nuget/CodeContracts.MSBuild/build/CodeContracts.MSBuild.props
@@ -129,7 +129,7 @@
      '$(CodeContractsUseBaseLine)' == ''">False</CodeContractsUseBaseLine>
     <!-- Baseline file -->
     <CodeContractsBaseLineFile Condition="
-     '$()CodeContractsBaseLineFile' == ''" />
+     '$(CodeContractsBaseLineFile)' == ''" />
 
     <!-- Contract reference assembly -->
     <CodeContractsReferenceAssembly Condition="


### PR DESCRIPTION
In Visual Studio, all switches are always saved to the project file. This creates unnecessary clutter, especially ugly with the new compact SDK-style projects. I am adding a .props file that initializes all switches to the same defaults as the unfortunately late VS extension did, except for enabling static checking by default. (The theory is that if the user did not want contract checking, they would not install the package in the first place.)