### PR TITLE
Mark package with developmentDependency=true

### DIFF
--- a/nuget/CodeContracts.MSBuild/CodeContracts.MSBuild.nuspec
+++ b/nuget/CodeContracts.MSBuild/CodeContracts.MSBuild.nuspec
@@ -3,6 +3,7 @@
     <metadata>
         <id>CodeContracts.MSBuild</id>
         <version>1.11.0-alpha</version>
+        <developmentDependency>true</developmentDependency>
         <title>Microsoft Code Contracts standalone package for MSBuild</title>
         <authors>Igor Oleinikov</authors>
         <projectUrl>https://github.com/Igorbek/CodeContracts.MSBuild</projectUrl>


### PR DESCRIPTION
Because it is, otherwise the package is added as dependency of the project importing the package.

Unfortunately, this is broken atm with the SDK projects (NuGet/Home#4125), but works with "classic" projects. With SDK, the user has to add the PrivateAssets=All attribute:
```xml
  <ItemGroup>
    <PackageReference Include="CodeContracts.MSBuild" Version="1.11.0-alpha" PrivateAssets="All" />
  </ItemGroup>
```